### PR TITLE
Set id_column as index in loaded dataframe and provide getter

### DIFF
--- a/adjacency_graphs/algorithms/twostep.py
+++ b/adjacency_graphs/algorithms/twostep.py
@@ -42,6 +42,7 @@ def TwoStepGraph(shp_path, id_column):
     data['CENTROID_YCOORDINATES'] = data.apply(
         lambda x: x['geometry'].centroid[1], 1
     )
+    data.set_index(id_column, inplace=True)
 
     loaded_geodata = ps.open(shp_path)
     loaded_polymap = create_polymap(shp_path,

--- a/adjacency_graphs/mggg_graph.py
+++ b/adjacency_graphs/mggg_graph.py
@@ -33,6 +33,11 @@ class MgggGraph(object):
         self.loaded_polymap = loaded_polymap
         self.neighbors = neighbors
 
+    def get_vertex_attrs(self, geoid, attrs=[]):
+        """ Get the attributes of the vertex with id geoid
+        """
+        return self.shape_df.loc[geoid, attrs or pd.IndexSlice[:]]
+
     def export_graph(self, output_path='graph.csv'):
         """ Export csv to output_path.
         """


### PR DESCRIPTION
Overview
-----

This PR sets the column `TwoStepGraph` is told is the id column as the index
on the dataframe loaded into the `MgggGraph`. As it stands, there's no cheap way to
extract the attributes of a specific vertex if you know it's ID. After this change, the
graph coming out of `TwoStepAlgorithm(path, id_column)` has a `get_vertex_attrs`
method that provides cheap access to all or a subset of a vertex's attributes.

Testing
-----

Load up your favorite shapefile and check out some vertices